### PR TITLE
fix minor mistakes in PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,14 +6,13 @@ pkgrel=1
 pkgdesc="Паренная репа нахуй"
 arch=('any')
 url="https://github.com/Zayac-The-Engineer/${pkgname}"
-license=('MIT')
+license=('GPL')
 depends=()
-makedepends=('git')
+makedepends=('git' 'cmake')
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/Zayac-The-Engineer/${pkgname}/archive/${pkgver}.tar.gz")
 md5sums=('SKIP')
 
 package() {
 	cd "$srcdir/$pkgname-$pkgver"
 	make DESTDIR="$pkgdir" install
-	install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -8,7 +8,7 @@ arch=('any')
 url="https://github.com/Zayac-The-Engineer/${pkgname}"
 license=('GPL')
 depends=()
-makedepends=('git' 'cmake')
+makedepends=('git' 'make')
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/Zayac-The-Engineer/${pkgname}/archive/${pkgver}.tar.gz")
 md5sums=('SKIP')
 


### PR DESCRIPTION
Your project uses GNU GPL, not MIT License, so you just have to add GPL to the license array in PKGBUILD and not include it in the package itself
Your projects requires make for building